### PR TITLE
don't run redundant CI on pull requests

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -6,8 +6,6 @@ name: Node.js CI
 on:
     # Run on all branches
     push:
-    # Run on all pull requests
-    pull_request:
 
 jobs:
     build:


### PR DESCRIPTION
commits in pull requests were ran through CI twice due to CI being enabled both for all commits and all pull requests. CI on pull requests is not needed as all commits are already run through CI