### PR TITLE
locking for prompt boxes

### DIFF
--- a/frontend/src/components/ContentPanel/ContentPanel.test.tsx
+++ b/frontend/src/components/ContentPanel/ContentPanel.test.tsx
@@ -94,7 +94,7 @@ test('Remove button should delete the correct promptIOBox', () => {
 
     const buttons = inputArea.parentElement?.getElementsByTagName('button');
     expect(buttons?.length).toBeGreaterThan(1);
-    const delButton = buttons?.[1] as HTMLButtonElement | undefined;
+    const delButton = buttons?.[2] as HTMLButtonElement | undefined;
 
     act(() => {
         delButton?.click();

--- a/frontend/src/components/ContentPanel/ContentPanelPrompts/index.tsx
+++ b/frontend/src/components/ContentPanel/ContentPanelPrompts/index.tsx
@@ -14,6 +14,7 @@ interface ContentPanelPromptsProps {
     generateOutput: (p: PromptData) => Promise<void>;
     setPromptOutput: (id: string, output: string) => void;
     addPromptBox: () => void;
+    lockPrompt: (id: string) => void;
 }
 
 export const ContentPanelPrompts: React.FC<ContentPanelPromptsProps> = ({
@@ -22,14 +23,13 @@ export const ContentPanelPrompts: React.FC<ContentPanelPromptsProps> = ({
     generateOutput,
     setPromptOutput,
     addPromptBox,
+    lockPrompt,
 }) => {
     //Callback to modify the output area of a PromptIOBox by id
     const setPromptInput = (id: string, input: string) => {
         //Replace the box that matches id with a new object where input is changed.
         setPromptBoxes((prev) =>
-            prev.map((o) =>
-                o.id === id ? { id: id, input: input, output: o.output } : o
-            )
+            prev.map((o) => (o.id === id ? { ...o, input: input } : o))
         );
     };
 
@@ -44,10 +44,12 @@ export const ContentPanelPrompts: React.FC<ContentPanelPromptsProps> = ({
                 return (
                     <PromptIOBox
                         key={p.id}
+                        id={p.id}
                         input={p.input}
                         output={p.output}
                         setInput={(s: string) => setPromptInput(p.id, s)}
                         setOutput={(s: string) => setPromptOutput(p.id, s)}
+                        lock={() => lockPrompt(p.id)}
                         generate={() => generateOutput(p)}
                         deleteSelf={
                             promptBoxes.length > 1

--- a/frontend/src/components/PromptIOBox.tsx
+++ b/frontend/src/components/PromptIOBox.tsx
@@ -10,6 +10,7 @@ export interface PromptData {
     id: string;
     input: string;
     output: string;
+    locked: boolean;
 }
 
 /**
@@ -17,24 +18,28 @@ export interface PromptData {
  * performing necessary actions of the box.
  */
 interface PromptIOBoxProps {
+    id: string;
     input: string;
     output: string;
     setInput: (s: string) => void;
     setOutput: (s: string) => void;
     generate: () => void;
     deleteSelf: (() => void) | null; //null --> don't show button
+    lock: (id: string) => void;
 }
 /**
  * Component containing editable textareas for Input/Output with AI
  * generation.
  */
 export const PromptIOBox: React.FC<PromptIOBoxProps> = ({
+    id,
     input,
     output,
     setInput,
     setOutput,
     generate,
     deleteSelf,
+    lock,
 }) => {
     return (
         <div className="mt-10 pt-4 px-8 w-1/2 min-w-fit flex flex-col items-center justify-around">
@@ -61,6 +66,11 @@ export const PromptIOBox: React.FC<PromptIOBoxProps> = ({
                     <FilledButton
                         onClick={generate}
                         name="Generate"
+                        colorPalette="primary"
+                    />
+                    <FilledButton
+                        onClick={() => lock(id)}
+                        name="lock"
                         colorPalette="primary"
                     />
                     {deleteSelf ? (


### PR DESCRIPTION
Locking for prompt boxes, so generate all only sends non-locked prompts to the backend