### PR TITLE
Bug in loading spinner

### DIFF
--- a/frontend/src/components/ContentPanel/index.tsx
+++ b/frontend/src/components/ContentPanel/index.tsx
@@ -116,7 +116,7 @@ export const ContentPanel: FC<ContentPanelProps> = () => {
             </div>
             {/* Loading spinner */}
             {loading && (
-                <div className="absolute inset-1/2">
+                <div className="fixed inset-1/2">
                     <Loader />
                 </div>
             )}


### PR DESCRIPTION
Changed the loading position from absolute to fixed, so the spinner is always shown at the center of screen.