### PR TITLE
Fix Cypress type hints

### DIFF
--- a/cypress/jsconfig.json
+++ b/cypress/jsconfig.json
@@ -1,0 +1,3 @@
+{
+    "include": ["../node_modules/cypress", "**/*.js"]
+}


### PR DESCRIPTION
Currently Cypress is not configured for any type hints for code completion, making writing tests tedious. Add a simple jsconfig from https://docs.cypress.io/guides/tooling/IDE-integration#Writing-Tests for autocompletion.