### PR TITLE
documentation now specifies to respond with 404 if a project is found…

### DIFF
--- a/docusaurus/docs/api-endpoints/api/user/projects/get-project.md
+++ b/docusaurus/docs/api-endpoints/api/user/projects/get-project.md
@@ -4,4 +4,4 @@ Get the project data by id.
 
 ## Response
 
-200 on success, 401 if no valid "user-token" cookie is found, and 404 if no project with given id is found. The response body contains the JSON string saved in the database.
+200 on success, 401 if no valid "user-token" cookie is found, and 404 if no project with given id is found or the project belongs to another user. The response body contains the JSON string saved in the database.


### PR DESCRIPTION
documentation now specifies to respond with 404 if a project is found but it belongs to another user