### PR TITLE
Eslint throw error on warnings

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,7 @@
         "test": "npm run test-pre && npm run test-run && npm run test-post",
         "tsc": "tsc",
         "dev": "run-p start-dev-database start-dev",
-        "lint": "eslint --ext .ts .",
+        "lint": "eslint --max-warnings=0 --ext .ts .",
         "build": "tsc",
         "start": "node build/index.js",
         "start-dev": "cross-env NODE_ENV=development ts-node-dev src/index.ts",

--- a/dummy/package.json
+++ b/dummy/package.json
@@ -7,7 +7,7 @@
         "test": "jest --verbose --runInBand --forceExit",
         "tsc": "tsc",
         "dev": "ts-node-dev src/index.ts",
-        "lint": "eslint --ext .ts .",
+        "lint": "eslint --max-warnings=0 --ext .ts .",
         "build": "tsc",
         "start": "node build/index.js"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
         "build": "react-scripts build",
         "test": "react-scripts test",
         "eject": "react-scripts eject",
-        "lint": "eslint --ext .tsx,.ts src"
+        "lint": "eslint --max-warnings=0 --ext .tsx,.ts src"
     },
     "eslintConfig": {
         "extends": [


### PR DESCRIPTION
Currently eslint only fails for fatal errors. Fix it so that eslint also fails on any warnings so that CI can catch them.
