### PR TITLE
Use notify-slack-action for slack alerts

### DIFF
--- a/.github/workflows/cd.deploy.yml
+++ b/.github/workflows/cd.deploy.yml
@@ -68,7 +68,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Alert on failed deployment
-              uses: distributhor/workflow-webhook@6684d6301159d8c6e1c6527f78d4db9b5d8e5fed
+              uses: ravsamhq/notify-slack-action@v2
+              with:
+                  status: ${{ job.status }}
+                  notification_title: '{workflow} has {status_message}'
+                  message_format: '{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>'
+                  footer: 'Linked Repo <{repo_url}|{repo}>'
               env:
-                  webhook_url: ${{ secrets.WEBHOOK_URL }}
-                  data: '{"text":"Continuous deployment failed on main!"}'
+                  SLACK_WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}

--- a/.github/workflows/cd.deploy.yml
+++ b/.github/workflows/cd.deploy.yml
@@ -70,7 +70,9 @@ jobs:
             - name: Alert on failed deployment
               uses: ravsamhq/notify-slack-action@v2
               with:
-                  status: ${{ job.status }}
+                  # explicit failure instead of ${{ job.status }} due to
+                  # different job (TODO: fix somehow? how about multiple dependencies?)
+                  status: 'failure'
                   notification_title: '{workflow} has {status_message}'
                   message_format: '{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>'
                   footer: 'Linked Repo <{repo_url}|{repo}>'

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -81,7 +81,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Alert on failed CI in main
-              uses: distributhor/workflow-webhook@6684d6301159d8c6e1c6527f78d4db9b5d8e5fed
+              uses: ravsamhq/notify-slack-action@v2
+              with:
+                  status: ${{ job.status }}
+                  notification_title: '{workflow} has {status_message}'
+                  message_format: '{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>'
+                  footer: 'Linked Repo <{repo_url}|{repo}>'
               env:
-                  webhook_url: ${{ secrets.WEBHOOK_URL }}
-                  data: '{"text":"Deployment failed!"}'
+                  SLACK_WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -83,7 +83,9 @@ jobs:
             - name: Alert on failed CI in main
               uses: ravsamhq/notify-slack-action@v2
               with:
-                  status: ${{ job.status }}
+                  # explicit failure instead of ${{ job.status }} due to
+                  # different job (TODO: fix somehow? how about multiple dependencies?)
+                  status: 'failure'
                   notification_title: '{workflow} has {status_message}'
                   message_format: '{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>'
                   footer: 'Linked Repo <{repo_url}|{repo}>'


### PR DESCRIPTION
https://github.com/bytecraftoy/aalto-2022/actions/runs/4163879033/jobs/7206179701

Slack webhook failed because it expects "text" json field but the webhook
action only supports a "data" field. Migrate to notify-slack-action which
should work properly. It also has better formatting for Slack messages.

