### PR TITLE
Clean up NODE_ENV logic

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -7,6 +7,7 @@ import cookieParser from 'cookie-parser';
 import { checkToken } from './middleware/checkToken';
 import expressAsyncHandler from 'express-async-handler';
 import { tokenReader } from './middleware/tokenReader';
+import { isProduction } from './utils/env';
 
 const app = express();
 app.use(cors);
@@ -19,7 +20,10 @@ app.use(requestLogger);
 
 app.use('/api/health', healthRouter);
 app.use('/api/user', userRouter);
-app.use(express.static('./public/'));
+// Static files are served by NGINX in production
+if (!isProduction()) {
+    app.use(express.static('./public/'));
+}
 app.use(checkToken);
 app.use('/api/export/', exportRouter);
 app.use('/api/textgen', apiRouter);

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -20,10 +20,7 @@ app.use(requestLogger);
 
 app.use('/api/health', healthRouter);
 app.use('/api/user', userRouter);
-// Static files are served by NGINX in production
-if (!isProduction()) {
-    app.use(express.static('./public/'));
-}
+app.use(express.static('./public/'));
 app.use(checkToken);
 app.use('/api/export/', exportRouter);
 app.use('/api/textgen', apiRouter);

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -7,7 +7,6 @@ import cookieParser from 'cookie-parser';
 import { checkToken } from './middleware/checkToken';
 import expressAsyncHandler from 'express-async-handler';
 import { tokenReader } from './middleware/tokenReader';
-import { isProduction } from './utils/env';
 
 const app = express();
 app.use(cors);

--- a/backend/src/db/pool.ts
+++ b/backend/src/db/pool.ts
@@ -1,9 +1,10 @@
 import { Pool } from 'pg';
 import dotenv from 'dotenv';
+import { isTesting } from '../utils/env';
 
 // dotenv may not be properly loaded for tests because the source file it's
 // normally called in isn't loaded
-if (process.env.NODE_ENV === 'test') {
+if (isTesting()) {
     dotenv.config();
 }
 

--- a/backend/src/db/pool.ts
+++ b/backend/src/db/pool.ts
@@ -4,7 +4,7 @@ import { isTesting } from '../utils/env';
 
 // dotenv may not be properly loaded for tests because the source file it's
 // normally called in isn't loaded
-if (isTesting()) {
+if (isTesting) {
     dotenv.config();
 }
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,11 +2,12 @@ import http from 'http';
 import { app } from './app';
 import { pool } from './db/pool';
 import { waitForDatabase } from './db/util';
+import { isTesting } from './utils/env';
 import { logger } from './utils/logger';
 
 const server = http.createServer(app);
 
-if (process.env.NODE_ENV !== 'test') {
+if (!isTesting()) {
     const PORT = process.env.PORT || 3030;
 
     waitForDatabase(pool, true)

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,7 +7,7 @@ import { logger } from './utils/logger';
 
 const server = http.createServer(app);
 
-if (!isTesting()) {
+if (!isTesting) {
     const PORT = process.env.PORT || 3030;
 
     waitForDatabase(pool, true)

--- a/backend/src/services/tokenService.ts
+++ b/backend/src/services/tokenService.ts
@@ -9,7 +9,7 @@ const tokenCookieName = 'user-token';
 const tokenCookieOptions: CookieOptions = {
     //the cookie must be unsecure in development
     //since otherwise browser won't send it over unsecure http
-    secure: !isDevelopment(),
+    secure: !isDevelopment,
     httpOnly: true,
     sameSite: 'strict',
 };

--- a/backend/src/services/tokenService.ts
+++ b/backend/src/services/tokenService.ts
@@ -2,15 +2,14 @@ import { Request, CookieOptions } from 'express';
 import { logger } from './../utils/logger';
 import { parseToken } from './userService';
 import { TokenPayload } from './../types/TokenPayload';
-
-const devMode = process.env.NODE_ENV === 'development';
+import { isDevelopment } from '../utils/env';
 
 const tokenCookieName = 'user-token';
 
 const tokenCookieOptions: CookieOptions = {
     //the cookie must be unsecure in development
     //since otherwise browser won't send it over unsecure http
-    secure: !devMode,
+    secure: !isDevelopment(),
     httpOnly: true,
     sameSite: 'strict',
 };

--- a/backend/src/utils/env.ts
+++ b/backend/src/utils/env.ts
@@ -1,4 +1,4 @@
 // NODE_ENV is a variable used by Express to configure runtime behaviour.
 export const isTesting = () => process.env.NODE_ENV === 'test';
 export const isDevelopment = () => process.env.NODE_ENV === 'development';
-export const isProduction = () => !isTesting && !isDevelopment;
+export const isProduction = () => !isTesting() && !isDevelopment();

--- a/backend/src/utils/env.ts
+++ b/backend/src/utils/env.ts
@@ -1,0 +1,4 @@
+// NODE_ENV is a variable used by Express to configure runtime behaviour.
+export const isTesting = () => process.env.NODE_ENV === 'test';
+export const isDevelopment = () => process.env.NODE_ENV === 'development';
+export const isProduction = () => !isTesting && !isDevelopment;

--- a/backend/src/utils/env.ts
+++ b/backend/src/utils/env.ts
@@ -1,4 +1,4 @@
 // NODE_ENV is a variable used by Express to configure runtime behaviour.
-export const isTesting = () => process.env.NODE_ENV === 'test';
-export const isDevelopment = () => process.env.NODE_ENV === 'development';
-export const isProduction = () => !isTesting() && !isDevelopment();
+export const isTesting = process.env.NODE_ENV === 'test';
+export const isDevelopment = process.env.NODE_ENV === 'development';
+export const isProduction = !isTesting && !isDevelopment;

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -1,21 +1,19 @@
 import { createLogger, transports, format } from 'winston';
+import { isDevelopment } from './env';
 
 /**
  * Determines the logging level based on the current environment.
- * NODE_ENV is a variable used by Express to configure runtime behaviour. In
- * production we only want http (and above) level of logging, but in development
- * all logs are enabled.
+ *  In production we only want http (and above) level of logging, but in
+ *  development all logs are enabled.
  * @return {string} The logging level to use.
  */
 const level = (): string => {
-    const env = process.env.NODE_ENV || 'development';
-    const isDevelopment = env === 'development';
-    return isDevelopment ? 'debug' : 'http';
+    return isDevelopment() ? 'debug' : 'http';
 };
 
 // Use pretty printing only for development environment, otherwise print on one line
 const formats = [format.timestamp(), format.json()];
-if (process.env.NODE_ENV === 'development') formats.push(format.prettyPrint());
+if (isDevelopment()) formats.push(format.prettyPrint());
 
 /**
  * Creates a Winston logger configured to log to the console and format messages as JSON.

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -8,12 +8,12 @@ import { isDevelopment } from './env';
  * @return {string} The logging level to use.
  */
 const level = (): string => {
-    return isDevelopment() ? 'debug' : 'http';
+    return isDevelopment ? 'debug' : 'http';
 };
 
 // Use pretty printing only for development environment, otherwise print on one line
 const formats = [format.timestamp(), format.json()];
-if (isDevelopment()) formats.push(format.prettyPrint());
+if (isDevelopment) formats.push(format.prettyPrint());
 
 /**
  * Creates a Winston logger configured to log to the console and format messages as JSON.


### PR DESCRIPTION
Use utility functions to clean up leaky logic around the codebase. Disable unneeded backend public folder in production.
