### PR TITLE
Override logging level with LOG_LEVEL, use warn in testing

### DIFF
--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -1,14 +1,20 @@
 import { createLogger, transports, format } from 'winston';
-import { isDevelopment } from './env';
+import { isDevelopment, isTesting } from './env';
 
 /**
  * Determines the logging level based on the current environment.
+ *  Logging levels are: error, warn, info, http, verbose, debug, silly
+ *  Use 'LOG_LEVEL' environment variable to override the default.
  *  In production we only want http (and above) level of logging, but in
  *  development all logs are enabled.
  * @return {string} The logging level to use.
  */
 const level = (): string => {
-    return isDevelopment ? 'debug' : 'http';
+    const env = process.env.LOG_LEVEL;
+    if (env) return env;
+    if (isDevelopment) return 'debug';
+    if (isTesting) return 'warn';
+    return 'http';
 };
 
 // Use pretty printing only for development environment, otherwise print on one line


### PR DESCRIPTION
Logging level can be override using LOG_LEVEL env, and make testing use 'warn' by default to reduce spam.
