### PR TITLE
Parallelize setup-project for a speed up

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "scripts": {
         "ds": "run-p dev:*",
         "docusaurus": "npm run build-docs && npm run start-docs",
-        "setup-project": "npm install && npm run setup:backend && npm run install:frontend && npm run install:dummy",
+        "setup-project": "npm install && run-p setup:backend install:frontend install:dummy",
         "build-project": "run-s build:*",
         "test-project": "run-s test:*",
         "lint-project": "run-s lint:*",


### PR DESCRIPTION
On my own system, setup-project runs twice as fast:
```bash
hyperfine --runs 3  --prepare "rm -rf backend/node_modules dummy/node_modules frontend/node_modules node_modules"  "npm run setup-project" "npm run setup-project-fast"
Benchmark 1: npm run setup-project
  Time (mean ± σ):     19.419 s ±  0.602 s    [User: 29.337 s, System: 6.785 s]
  Range (min … max):   18.951 s … 20.098 s    3 runs

Benchmark 2: npm run setup-project-fast
  Time (mean ± σ):      9.902 s ±  0.085 s    [User: 29.895 s, System: 7.151 s]
  Range (min … max):    9.809 s …  9.976 s    3 runs

Summary
  'npm run setup-project-fast' ran
    1.96 ± 0.06 times faster than 'npm run setup-project'
```

In CI, the average time seems to go from around 40-45 seconds to 30-35 seconds, for a 25% speedup.
We can't parallelize root's install due requiring the run-p dependency first.
