### PR TITLE
IO Box delete button no longer appears when locked

### DIFF
--- a/frontend/src/components/ContentPanel/ContentPanelPrompts/PromptIOBox/IOBoxBar/index.tsx
+++ b/frontend/src/components/ContentPanel/ContentPanelPrompts/PromptIOBox/IOBoxBar/index.tsx
@@ -43,7 +43,7 @@ export const IOBoxBar: React.FC<IOBoxBarProps> = ({
                 colorPalette={locked ? 'secondary' : 'tertiary'}
                 visible={locked || showButtons}
             />
-            {deleteSelf ? (
+            {deleteSelf && !locked ? (
                 <IOBoxButton
                     icon="XMarkIcon"
                     onClick={() => deleteSelf?.()}


### PR DESCRIPTION
Quick fix to hide the IO box delete button when the IO box is locked.