### PR TITLE
less spammy queries

### DIFF
--- a/backend/src/db/queries.ts
+++ b/backend/src/db/queries.ts
@@ -24,8 +24,9 @@ const executeQuery = async (
     try {
         const res = await client.query(query);
         client.release();
-        logger.debug('db_query_done', { res });
-        return res.rows as unknown[];
+        const result = res.rows;
+        logger.debug('db_query_done', { result });
+        return result as unknown[];
     } catch (e) {
         client.release();
         logger.error('db_query_fail', { error: e, query });


### PR DESCRIPTION
query_done logger had too much useless data. just the returned rows is enough.