### PR TITLE
Trust local proxies for X-Forwarded-* headers

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -25,6 +25,7 @@ const app = express();
 const getApp = async (): Promise<express.Express> => {
     // Trust proxy headers
     // Required for Express to trust the X-Forwarded-* headers from NGINX
+    // https://expressjs.com/en/guide/behind-proxies.html
     app.set('trust proxy', ['loopback', 'linklocal', 'uniquelocal']);
 
     if (!isTesting) {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -28,7 +28,7 @@ const getApp = async (): Promise<express.Express> => {
     app.set('trust proxy', [
         'linklocal',
         'uniquelocal',
-        'localhost',
+        '127.0.0.1',
         'loopback',
     ]);
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -23,6 +23,15 @@ import { pool } from './db/pool';
 const app = express();
 
 const getApp = async (): Promise<express.Express> => {
+    // Trust proxy headers
+    // Required for Express to trust the X-Forwarded-* headers from NGINX
+    app.set('trust proxy', [
+        'linklocal',
+        'uniquelocal',
+        'localhost',
+        'loopback',
+    ]);
+
     if (!isTesting) {
         await waitForDatabase(pool, true);
         const adminRouter = await getAdminRouter();

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -25,12 +25,7 @@ const app = express();
 const getApp = async (): Promise<express.Express> => {
     // Trust proxy headers
     // Required for Express to trust the X-Forwarded-* headers from NGINX
-    app.set('trust proxy', [
-        'linklocal',
-        'uniquelocal',
-        '127.0.0.1',
-        'loopback',
-    ]);
+    app.set('trust proxy', ['loopback', 'linklocal', 'uniquelocal']);
 
     if (!isTesting) {
         await waitForDatabase(pool, true);


### PR DESCRIPTION
AdminJS login breaks with secure cookies because Express does not trurst X-Forwarded-Proto header passed by NGINX. Let's trust local and private use addresses to make ExpressJS function with reverse proxies properly.

https://expressjs.com/en/guide/behind-proxies.html