### PR TITLE
Indicate panels properties

### DIFF
--- a/frontend/src/components/ContentPanel/ContentPanelHeader/index.tsx
+++ b/frontend/src/components/ContentPanel/ContentPanelHeader/index.tsx
@@ -15,7 +15,7 @@ interface ContentPanelHeaderProps {
 
     saveState: (force?: boolean) => Promise<void>;
     setOpen: React.Dispatch<React.SetStateAction<boolean>>;
-    hasCustomParameters: boolean;
+    overrideTheme: boolean;
 }
 
 export const ContentPanelHeader: React.FC<ContentPanelHeaderProps> = ({
@@ -24,25 +24,23 @@ export const ContentPanelHeader: React.FC<ContentPanelHeaderProps> = ({
     setPopup,
     saveState,
     setOpen,
-    hasCustomParameters,
+    overrideTheme,
 }) => {
     interface IconAsteriskProps {
-        hasCustomParameters: boolean;
+        overrideTheme: boolean;
     }
-    const IconAsterisk: React.FC<IconAsteriskProps> = ({
-        hasCustomParameters,
-    }) => {
+    const IconAsterisk: React.FC<IconAsteriskProps> = ({ overrideTheme }) => {
         let text = '';
-        if (hasCustomParameters) {
+        if (overrideTheme) {
             text = '*';
         }
         return (
             <div
-                className="flex-1 z-[15] pl-8"
+                className="flex z-[15] pl-8"
                 style={{
                     position: 'relative',
-                    right: 52,
-                    bottom: 10,
+                    right: 50,
+                    bottom: -4,
                     pointerEvents: 'none',
                     minWidth: 40,
                 }}
@@ -55,7 +53,10 @@ export const ContentPanelHeader: React.FC<ContentPanelHeaderProps> = ({
     return (
         <div className="flex flex-row justify-center items-center h-16 px-4 mt-6">
             <PromptCategoryBox category={category} setCategory={setCategory} />
-            <div data-testid="panel-settings" className="h-full pl-2 z-[15]">
+            <div
+                data-testid="panel-settings"
+                className="flex flex-row h-full pl-2 z-[15]"
+            >
                 <DropdownMenu
                     icon="Cog6Tooth"
                     items={[
@@ -76,8 +77,8 @@ export const ContentPanelHeader: React.FC<ContentPanelHeaderProps> = ({
                         },
                     ]}
                 />
+                <IconAsterisk overrideTheme={overrideTheme} />
             </div>
-                <IconAsterisk hasCustomParameters={hasCustomParameters} />
         </div>
     );
 };

--- a/frontend/src/components/ContentPanel/ContentPanelHeader/index.tsx
+++ b/frontend/src/components/ContentPanel/ContentPanelHeader/index.tsx
@@ -15,6 +15,7 @@ interface ContentPanelHeaderProps {
 
     saveState: (force?: boolean) => Promise<void>;
     setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    hasCustomParameters: boolean;
 }
 
 export const ContentPanelHeader: React.FC<ContentPanelHeaderProps> = ({
@@ -23,7 +24,34 @@ export const ContentPanelHeader: React.FC<ContentPanelHeaderProps> = ({
     setPopup,
     saveState,
     setOpen,
+    hasCustomParameters,
 }) => {
+    interface IconAsteriskProps {
+        hasCustomParameters: boolean;
+    }
+    const IconAsterisk: React.FC<IconAsteriskProps> = ({
+        hasCustomParameters,
+    }) => {
+        let text = '';
+        if (hasCustomParameters) {
+            text = '*';
+        }
+        return (
+            <div
+                className="flex-1 z-[15] pl-8"
+                style={{
+                    position: 'relative',
+                    right: 52,
+                    bottom: 10,
+                    pointerEvents: 'none',
+                    minWidth: 40,
+                }}
+            >
+                {text}
+            </div>
+        );
+    };
+
     return (
         <div className="flex flex-row justify-center items-center h-16 px-4 mt-6">
             <PromptCategoryBox category={category} setCategory={setCategory} />
@@ -49,6 +77,7 @@ export const ContentPanelHeader: React.FC<ContentPanelHeaderProps> = ({
                     ]}
                 />
             </div>
+                <IconAsterisk hasCustomParameters={hasCustomParameters} />
         </div>
     );
 };

--- a/frontend/src/components/ContentPanel/index.tsx
+++ b/frontend/src/components/ContentPanel/index.tsx
@@ -85,8 +85,6 @@ export const ContentPanel: FC<ContentPanelProps> = ({ id }) => {
         if (!open) saveState();
     }, [open]);
 
-    const hasCustomParameters: boolean = parameters != theme.globalParameters;
-
     return (
         //Take up full space, and center the content panel in it
         <div className="relative w-full h-full flex-1">
@@ -116,7 +114,7 @@ export const ContentPanel: FC<ContentPanelProps> = ({ id }) => {
                         setPopup={setPopup}
                         saveState={saveState}
                         setOpen={setOpen}
-                        hasCustomParameters={hasCustomParameters}
+                        overrideTheme={overrideTheme}
                     />
 
                     {/* Pop-up window used to add n boxes. Hidden by default*/}

--- a/frontend/src/components/ContentPanel/index.tsx
+++ b/frontend/src/components/ContentPanel/index.tsx
@@ -85,6 +85,8 @@ export const ContentPanel: FC<ContentPanelProps> = ({ id }) => {
         if (!open) saveState();
     }, [open]);
 
+    const hasCustomParameters: boolean = parameters != theme.globalParameters;
+
     return (
         //Take up full space, and center the content panel in it
         <div className="relative w-full h-full flex-1">
@@ -114,6 +116,7 @@ export const ContentPanel: FC<ContentPanelProps> = ({ id }) => {
                         setPopup={setPopup}
                         saveState={saveState}
                         setOpen={setOpen}
+                        hasCustomParameters={hasCustomParameters}
                     />
 
                     {/* Pop-up window used to add n boxes. Hidden by default*/}


### PR DESCRIPTION
In the Content Panel Header, on the top-right corner of the cog icon for the drop down menu, it will display an asterisk if the settings are modified.

This means selecting Parameters from the drop down menu then enabling theme settings override then either selecting a preset theme or ticking 'Advanced settings' and adjusting any of the sliders.

The asterisk disappears if 'Override theme settings' is ticked back off.