### PR TITLE
Dev sql migrations

### DIFF
--- a/backend/dev_migrations/1682008155599_add-admin-user.sql
+++ b/backend/dev_migrations/1682008155599_add-admin-user.sql
@@ -1,0 +1,3 @@
+-- Up Migration
+INSERT INTO users (id, name, password_hash, role)
+VALUES ('8ed32f81-31c6-488d-aa1a-416ea13e8291', 'superadmin', '$2b$10$In/OFg5exXq3cn69YwQbv.k3vwnr0k/HLYaK7Jj0bTRl1KBbawQY6', 'superadmin');

--- a/backend/dev_migrations/1682008155599_add-admin-user.sql
+++ b/backend/dev_migrations/1682008155599_add-admin-user.sql
@@ -1,3 +1,4 @@
 -- Up Migration
+-- Unhashed password is 'superadmin'
 INSERT INTO users (id, name, password_hash, role)
 VALUES ('8ed32f81-31c6-488d-aa1a-416ea13e8291', 'superadmin', '$2b$10$In/OFg5exXq3cn69YwQbv.k3vwnr0k/HLYaK7Jj0bTRl1KBbawQY6', 'superadmin');

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,8 @@
         "start-dev": "cross-env NODE_ENV=development ts-node-dev src/index.ts",
         "start-dev-database": "(docker-compose down || echo skipped docker-compose down) && docker-compose up --build",
         "copy-sample-env": "cpy .env-sample . --no-overwrite --rename=.env || echo skipped copy-sample-env",
-        "migrate": "node-pg-migrate"
+        "migrate": "node-pg-migrate",
+        "dev-migrate": "node-pg-migrate -m dev_migrations"
     },
     "keywords": [],
     "author": "",

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -7,8 +7,10 @@ import { logger } from '../utils/logger';
 import migrate, { RunnerOption } from 'node-pg-migrate';
 import { Client } from 'pg';
 import { databaseConfig } from './pool';
+import { RunMigration } from 'node-pg-migrate/dist/migration';
+import { isProduction } from '../utils/env';
 
-const runMigrations = async () => {
+const migrateFolder = async (folder: string): Promise<RunMigration[]> => {
     logger.info('migrations_start');
 
     // we need to create a new client instead of using a pool because the
@@ -18,7 +20,7 @@ const runMigrations = async () => {
 
     const options: RunnerOption = {
         dbClient: client,
-        dir: 'migrations',
+        dir: folder,
         direction: 'up',
         log: (msg: string) => {
             logger.info('migrate', { msg });
@@ -31,6 +33,19 @@ const runMigrations = async () => {
     await client.end();
 
     logger.info('migrations_done', { res });
+    return res;
+};
+
+const runMigrations = async () => {
+    logger.info('migrations_start');
+    const res = await migrateFolder('migrations');
+    logger.info('migrations_done', { res });
+
+    if (!isProduction) {
+        logger.info('dev_migrations_start');
+        const dev_res = await migrateFolder('dev_migrations');
+        logger.info('dev_migrations_done', { dev_res });
+    }
 };
 
 export { runMigrations };

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -39,13 +39,11 @@ const migrateFolder = async (folder: string): Promise<RunMigration[]> => {
 const runMigrations = async () => {
     logger.info('migrations_start');
     const res = await migrateFolder('migrations');
-    logger.info('migrations_done', { res });
 
     if (!isProduction) {
-        logger.info('dev_migrations_start');
-        const dev_res = await migrateFolder('dev_migrations');
-        logger.info('dev_migrations_done', { dev_res });
+        await migrateFolder('dev_migrations');
     }
+    logger.info('migrations_done', { res });
 };
 
 export { runMigrations };

--- a/backend/src/routers/admin.ts
+++ b/backend/src/routers/admin.ts
@@ -80,6 +80,15 @@ const getAdminRouter = async (): Promise<Router> => {
                 options: {
                     properties: {
                         password_hash: { isVisible: false },
+                        settings: { isVisible: false },
+                        created: { isEditable: false },
+                        role: {
+                            availableValues: [
+                                { label: 'Normal', value: 'normal' },
+                                { label: 'Admin', value: 'admin' },
+                                { label: 'Superadmin', value: 'superadmin' },
+                            ],
+                        },
                     },
                 },
                 features: [


### PR DESCRIPTION
Add a seperate dev_migrations folder for database migrations run only in development and testing. This enables us to create default dev mode data for quicker and easier development. The folder already comes with a migration that creates a superadmin user (credintals superadmin:superadmin) that can be used to log in to the AdminJS panel. The developer migrations are run after all the normal ones.
