### PR TITLE
Backend Dockerfile improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
-node_modules
+backend/build
 backend/node_modules
+frontend/build
 frontend/node_modules
+node_modules

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:18 as builder
-ENV ROOT_PATH /usr/src/app
+ENV BUILD_DIR /usr/src/app
 
-WORKDIR ${ROOT_PATH}/frontend
+WORKDIR ${BUILD_DIR}/frontend
 
 # copy frontend config and install dependencies
 COPY ./frontend/package*.json .
@@ -13,10 +13,10 @@ COPY ./frontend .
 # build frontend
 RUN npm run build
 
-WORKDIR ${ROOT_PATH}/backend
+WORKDIR ${BUILD_DIR}/backend
 
 # copy frontend build to backend public folder
-RUN mkdir ./build && cp -r "$ROOT_PATH/frontend/build" ./build/public
+RUN mkdir ./build && cp -r "$BUILD_DIR/frontend/build" ./build/public
 
 # copy backend config and install dependencies
 COPY ./backend/package*.json .
@@ -29,20 +29,20 @@ COPY ./backend .
 RUN npm run build
 
 FROM node:18-alpine
-ENV ROOT_PATH /usr/src/app
+ENV BUILD_DIR /usr/src/app
 
 WORKDIR /home/app
 
 RUN chown -R node:node /home/app
 
 # Install production dependencies
-COPY --from=builder ${ROOT_PATH}/backend/package*.json ./
+COPY --from=builder ${BUILD_DIR}/backend/package*.json ./
 RUN npm ci --omit=dev
 
 # copy only needed files from builder
-COPY --from=builder --chown=node:node ${ROOT_PATH}/backend/migrations/ ./migrations/
-COPY --from=builder --chown=node:node ${ROOT_PATH}/backend/files/ ./files/
-COPY --from=builder --chown=node:node ${ROOT_PATH}/backend/build ./
+COPY --from=builder --chown=node:node ${BUILD_DIR}/backend/migrations/ ./migrations/
+COPY --from=builder --chown=node:node ${BUILD_DIR}/backend/files/ ./files/
+COPY --from=builder --chown=node:node ${BUILD_DIR}/backend/build/ ./
 
 USER node
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,15 +1,51 @@
-FROM node:18
-WORKDIR /usr/src/app
-# copy frontend and build it
-COPY ./frontend ./frontend
-RUN cd frontend && npm i && npm run build && cd ..
-# copy all backend files
-COPY ./backend ./backend
+FROM node:18 as builder
+ENV ROOT_PATH /usr/src/app
+
+WORKDIR ${ROOT_PATH}/frontend
+
+# copy frontend config and install dependencies
+COPY ./frontend/package*.json .
+RUN npm ci
+
+# copy frontend code
+COPY ./frontend .
+
+# build frontend
+RUN npm run build
+
+WORKDIR ${ROOT_PATH}/backend
+
 # copy frontend build to backend public folder
-RUN mkdir ./backend/public ; cp -r ./frontend/build/* ./backend/public/ && rm -r frontend
+RUN mkdir ./build && cp -r "$ROOT_PATH/frontend/build" ./build/public
+
+# copy backend config and install dependencies
+COPY ./backend/package*.json .
+RUN npm ci
+
+# copy all backend files
+COPY ./backend .
+
 # build backend
-RUN cd ./backend && npm run setup && npm run build
+RUN npm run build
+
+FROM node:18-alpine
+ENV ROOT_PATH /usr/src/app
+
+WORKDIR /home/app
+
+RUN chown -R node:node /home/app
+
+# Install production dependencies
+COPY --from=builder ${ROOT_PATH}/backend/package*.json ./
+RUN npm ci --omit=dev
+
+# copy only needed files from builder
+COPY --from=builder --chown=node:node ${ROOT_PATH}/backend/migrations/ ./migrations/
+COPY --from=builder --chown=node:node ${ROOT_PATH}/backend/files/ ./files/
+COPY --from=builder --chown=node:node ${ROOT_PATH}/backend/build ./
+
+USER node
 
 EXPOSE 3030
 
-CMD cd ./backend && npm start
+CMD ["node", "index.js"]

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -16,6 +16,16 @@ if (!isTesting) {
 
     getServer()
         .then((server) => {
+            // handle SIGTERM gracefully
+            process.on('SIGTERM', () => {
+                logger.info('sigterm_closing_server');
+                // Perform any necessary cleanup, such as closing database connections or finishing ongoing requests
+                server.close(() => {
+                    logger.info('server_closed');
+                    process.exit(0);
+                });
+            });
+
             logger.info('started');
             server.listen(PORT, () => logger.info('started', { port: PORT }));
         })


### PR DESCRIPTION
- seperate to build and runtime stage, runtime only has production dependencies installed
- run backend as unpriviliged node user for security
- don't copy unnecessary files
- use minified alpine image for runtime for smaller container size
- use npm ci instead of install for faster install
- Gracefully handle SIGTERM so the application closes without a timeout
